### PR TITLE
Remove branch build configuration from appveyor.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,3 @@
-branches:
-  only:
-    - master
-
 cache: .tox
 
 environment:


### PR DESCRIPTION
Seems like it should be fine to build all branches, and in fact that's good to verify that PRs work properly. Any reason not to do this?