### PR TITLE
Enables fonts other than Arial and Courier New

### DIFF
--- a/cmu_graphics/shape_logic.py
+++ b/cmu_graphics/shape_logic.py
@@ -1623,7 +1623,7 @@ def getFont(baseFontName, isBold=False, isItalic=False):
     elif baseFontName.lower() in ('serif', 'sans-serif', 'cursive', 'fantasy', 'monospace'):
         fontName = baseFontName.lower()
     else:
-        fontName = 'Arial'
+        fontName = baseFontName
 
     bold = cairo.FONT_WEIGHT_BOLD if isBold else cairo.FONT_WEIGHT_NORMAL
     italic = cairo.FONT_SLANT_ITALIC if isItalic else cairo.FONT_SLANT_NORMAL


### PR DESCRIPTION
This change allows users to use fonts other than Arial and Courier New. This is achieved by changing getFont() in shape_logic.py to actually use the baseFontName argument, whereas currently it forces users to use Arial if baseFontName is not one of several predefined fonts. This decision was likely made for avoiding compatibility issues, but the change allows students larger freedom in designing their offline projects.