### PR TITLE
Fix how often onStep is called.

### DIFF
--- a/cmu_graphics/cmu_graphics.py
+++ b/cmu_graphics/cmu_graphics.py
@@ -722,7 +722,7 @@ class App(object):
                 should_redraw = had_event
 
                 msPassed = pygame.time.get_ticks() - lastTick
-                if (math.floor(1000 / self.stepsPerSecond) - msPassed < 10):
+                if (1000 / self.stepsPerSecond - msPassed < 1):
                     lastTick = pygame.time.get_ticks()
                     if not (self.paused or self.stopped):
                         self.callUserFn('onStep', ())


### PR DESCRIPTION
This change fixes how often `onStep` is called by using a tighter tolerance for how often to call it based on the milli-seconds passed since the last tick. This is important because any programs that count ticks to estimate time elapsed were previously very inaccurate. For a `stepsPerSecond` of 30, the old code would drift by 14.5 seconds every minute for a simple stopwatch, which is excessive and noticeable. This modified version only drifts 0.3 seconds.

If a student needs more accuracy, they should probably hook the `onMainLoopEvent` to get the exact milli-seconds passed each loop and do the math themselves.