### PR TITLE
Fix bug: Shapes not resizing when screen resizes after upgrade to version 1.1.32

### DIFF
--- a/cmu_graphics/cmu_graphics.py
+++ b/cmu_graphics/cmu_graphics.py
@@ -590,6 +590,7 @@ class App(object):
             return
         self.updateScreen(newScreen)
         self.callUserFn('onResize', ())
+        self.redrawAllWrapper()
 
     def getLeft(self):
         return 0

--- a/cmu_graphics/cmu_graphics.py
+++ b/cmu_graphics/cmu_graphics.py
@@ -589,8 +589,9 @@ class App(object):
         if not self._running:
             return
         self.updateScreen(newScreen)
-        self.callUserFn('onResize', ())
-        self.redrawAllWrapper()
+        self.callUserFn('onResize', (), redraw=False)
+        if self._isMvc:
+            self.redrawAllWrapper()
 
     def getLeft(self):
         return 0


### PR DESCRIPTION
Hello,

I am a CS rising sophomore at CMU-Q and part of the CA team for the 15-112 course this summer: [15-112 Staff](https://web2.qatar.cmu.edu/cs/15112/staff/pics.html).

We have noticed an issue where shapes do not resize when the screen is resized after upgrading to version 1.1.32 of cmu_graphics. This behavior was different in previous versions where shapes resized as expected.

The issue seems to have been introduced by the following commit: [Commit #54](https://github.com/cmu-cs-academy/desktop-cmu-graphics/pull/54). I'm curious to understand the rationale behind this change and how it was accepted. 😁

If there is a new way to handle this, clarifications would be appreciated.

In the meantime, I have re-added `self.redrawAllWrapper()` in the `onResize()` function (line 593) to address the issue.

Thank you for your attention to this matter.