### PR TITLE
New feature improved automatic resizing

### DIFF
--- a/cmu_graphics/cmu_graphics.py
+++ b/cmu_graphics/cmu_graphics.py
@@ -545,6 +545,9 @@ class App(object):
         self._running = False
         self.textInputs = []
 
+        self._autoResize = False
+        self._keepAspectRation = False
+
         self.inspector = shape_logic.Inspector(self)
         self._inspectorEnabled = True
         self.shouldPrintCtrlWarning = True
@@ -565,7 +568,23 @@ class App(object):
     def set_stopped(self, _):
         raise Exception('App.stopped is readonly')
     stopped = property(get_stopped, set_stopped)
+    
+    def get_autoResize(self):
+        return self._stopped
+    def set_autoResize(self, value):
+        if not isinstance(value, bool):
+            raise Exception('App.autoResize is a boolean')
+        self._autoResize = value
+    autoResize = property(get_autoResize, set_autoResize)
 
+    def get_keepAspectRatio(self):
+        return self._stopped
+    def set_keepAspectRatio(self, value):
+        if not isinstance(value, bool):
+            raise Exception('App.keepAspectRatio is a boolean')
+        self._keepAspectRation = value
+    keepAspectRatio = property(get_keepAspectRatio, set_keepAspectRatio)
+    
     def getStepsPerSecond(self):
         return self._stepsPerSecond
     def setStepsPerSecond(self, value):
@@ -753,7 +772,8 @@ class AppWrapper(object):
                          'printFullTracebacks'])
     readWriteAttrs = set(['height', 'paused', 'stepsPerSecond', 'group',
                           'title', 'width', 'background',
-                          'beatsPerMinute', 'maxShapeCount', 'inspectorEnabled' ])
+                          'beatsPerMinute', 'maxShapeCount', 'inspectorEnabled',
+                          'autoResize', 'keepAspectRatio'  ])
     allAttrs = readOnlyAttrs | readWriteAttrs
 
     def __init__(self, app):


### PR DESCRIPTION
Tries to address:

- #69

My approach:
if user wants cmu_graphics to handle resizing automatically for him,
then when screen resize:
- draw everything using the previous code at starting width and height size
- once the code gives back a pygame image scale that image to the new width and height
- if user want a same aspect ratio, scale to the smallest of x-scale and y-scale and offset the image so it is centred

I implemented the above faithfully but unfortunately it didn't work as I excepted and created a bug where the screen would constantly flicker.
I feel like there is a not so complicated way to fix this but I am unsure as to what it would be.
Once fixed this would be a great new feature to merge.