### PR TITLE
Program crashes when inspector is used on a shape with a RGB gradient fill

### DIFF
--- a/cmu_graphics/shape_logic.py
+++ b/cmu_graphics/shape_logic.py
@@ -2733,6 +2733,9 @@ class Inspector(object):
                 if isinstance(value, str):
                     result += value
                     result += ', '
+                elif isinstance(value, RGB):
+                    result += value._strVal
+                    result += ', '
                 else:
                     result += value.attrs['strVal']
                     result += ', '


### PR DESCRIPTION
Holding control to open the inspector and hovering over a shape with a fill set to a gradient of rgb values causes the program to freeze and the error 'AttributeError: 'rgb' object has no attribute 'attrs'

This fix adds a separate check in the string conversion, checking if it is apart of the RGB class and adding the string representation instead of the class object.