### PR TITLE
Inspector's main tooltip and mouse tooltip is hardcoded to an app size of 400x400

### DIFF
--- a/cmu_graphics/shape_logic.py
+++ b/cmu_graphics/shape_logic.py
@@ -2919,11 +2919,11 @@ class Inspector(object):
         h = 12
         margin = 10
         pointLabelCenterX = min(
-            400 - margin - w / 2,
+            self.app.width - margin - w / 2,
             max(margin + w / 2, self.bestX - 10)
         )
         pointLabelCenterY = min(
-            400 - margin - h / 2,
+            self.app.height - margin - h / 2,
             max(margin + h / 2, self.bestY - 10)
         )
 
@@ -2977,7 +2977,7 @@ class Inspector(object):
         lineHeight = 12
         infoHeight = lineHeight * len(newLines)
         ctx.rectangle(
-            400 - 2 * margin - infoWidth,
+            self.app.width - 2 * margin - infoWidth,
             minTop,
             infoWidth + 2 * margin,
             infoHeight + margin
@@ -2996,7 +2996,7 @@ class Inspector(object):
 
             drawCenteredText(
                 firstword,
-                400 -
+                self.app.width -
                     margin -
                     infoWidth / 2 -
                     (newlineWidth + firstwordWidth) / 2 +
@@ -3007,7 +3007,7 @@ class Inspector(object):
             ctx.select_font_face(*getFont('arial'))
             drawCenteredText(
                 newline,
-                400 -
+                self.app.width -
                     margin -
                     infoWidth / 2 +
                     (newlineWidth + firstwordWidth) / 2 -


### PR DESCRIPTION
Changing the hardcoded 400 to app.width seems to remedy this issue

Fix for #85 