### PR TITLE
Cmu image improvements

### DIFF
--- a/cmu_graphics/shape_logic.py
+++ b/cmu_graphics/shape_logic.py
@@ -451,13 +451,15 @@ def loadImageFromStringReference(reference):
     return PILWrapper(image)
 
 def loadImage(reference):
-    if isinstance(reference, PILWrapper):
-        image = reference
+    if hashReference(reference) not in activeDrawing.images:
+        if isinstance(reference, PILWrapper):
+            image = reference
+        else:
+            image = loadImageFromStringReference(reference)
+        surface = image.surface
+        activeDrawing.images[hashReference(reference)] = surface
     else:
-        image = loadImageFromStringReference(reference)
-
-    surface = image.surface
-    activeDrawing.images[hashReference(reference)] = surface
+        surface = activeDrawing.images[hashReference(reference)]
 
     return {'width': surface.get_width(), 'height': surface.get_height()}
 

--- a/cmu_graphics/shape_logic.py
+++ b/cmu_graphics/shape_logic.py
@@ -213,6 +213,9 @@ def typeError(obj, attr, value, typeName, isFn):
         else:
             callSpec = '{className}.{attr}'.format(className=t(obj.__class__.__name__), attr=t(attr))
     valueType = type(value).__name__
+    if isinstance(value,Image.Image):
+        value = "ImageFile"
+        valueType = 'PIL.Image)\n(did you forget to wrap your PIL.Image in a CMUImage?'
     err = t(
         '{{error}}: {{callSpec}} should be {{typeName}} (but {{value}} is of type {{valueType}})',
         {'error': t('TypeError'), 'callSpec': callSpec, 'typeName': typeName, 'value': repr(value), 'valueType': valueType}


### PR DESCRIPTION
Two changes have been made:
- Passing a PILImage to `Image()` or `drawImage()` functions now gives an appropriate error with a suggestion on the potential source of the error (addresess #67)
- Drawing images from strings is now much much faster because we check if the string is cached before doing all the previous logic

This PR introduces useful changes without much modification, so hopefully it can be merged quickly for the student to use.