### PR TITLE
Fix bug in App class's handleKeyRelease method

### DIFF
--- a/cmu_graphics/cmu_graphics.py
+++ b/cmu_graphics/cmu_graphics.py
@@ -378,6 +378,13 @@ def _safeMethod(appMethod):
 # Based on Lukas Peraza's pygame framework
 # https://github.com/LBPeraza/Pygame-Asteroids
 class App(object):
+    shiftMap = { '1':'!', '2':'@', '3':'#', '4':'$', '5':'%', '6':'^', '7':'&', '8':'*',
+                     '9':'(', '0':')', '[':'{', ']':'}', '/':'?', '=':'+', '\\':'|', '\'':'"',
+                     ',':'<', '.':'>', '-':'_', ';':':', '`':'~' }
+    unShiftMap = { '!':'1', '@':'2', '#':'3', '$':'4', '%':'5', '^':'6', '&':'7', '*':'8',
+                    '(':'9', ')':'0', '{':'[', '}':']', '?':'/', '+':'=', '|':'\\', '"':'\'',
+                   '<':',', '>':'.', '_':'-', ':':';', '~':'`' }
+    
     def printFullTracebacks(self):
         shape_logic.printFullTracebacks()
 
@@ -473,15 +480,11 @@ class App(object):
                        pygame.K_RIGHT: 'right', pygame.K_LEFT: 'left', pygame.K_UP: 'up', pygame.K_DOWN: 'down',
                        pygame.K_RCTRL: 'ctrl', pygame.K_LCTRL: 'ctrl'}
 
-        shiftMap = { '1':'!', '2':'@', '3':'#', '4':'$', '5':'%', '6':'^', '7':'&', '8':'*',
-                     '9':'(', '0':')', '[':'{', ']':'}', '/':'?', '=':'+', '\\':'|', '\'':'"',
-                     ',':'<', '.':'>', '-':'_', ';':':', '`':'~' }
-
         # Punctuation, numbers, and letters
         if 33 < keyCode < 127:
             key = chr(keyCode)
             if (modifierMask & pygame.KMOD_SHIFT):
-                key = shiftMap.get(key, key).upper()
+                key = App.shiftMap.get(key, key).upper()
             return key
         return keyNameMap.get(keyCode, None)
 
@@ -534,6 +537,10 @@ class App(object):
             return
         if key.upper() in self._allKeysDown: self._allKeysDown.remove(key.upper())
         if key.lower() in self._allKeysDown: self._allKeysDown.remove(key.lower())
+        if key in App.shiftMap and App.shiftMap[key] in self._allKeysDown:
+            self._allKeysDown.remove(App.shiftMap[key])
+        if key in App.unShiftMap and App.unShiftMap[key] in self._allKeysDown:
+            self._allKeysDown.remove(App.unShiftMap[key])
 
         modifiers = self.getModifiers(modifierMask)
         self.callUserFn('onKeyRelease', (key, modifiers))

--- a/cmu_graphics/cmu_graphics.py
+++ b/cmu_graphics/cmu_graphics.py
@@ -375,16 +375,18 @@ def _safeMethod(appMethod):
                 cleanAndClose()
     return m
 
+SHIFT_MAP = { '1':'!', '2':'@', '3':'#', '4':'$', '5':'%', '6':'^', '7':'&', '8':'*',
+                     '9':'(', '0':')', '[':'{', ']':'}', '/':'?', '=':'+', '\\':'|', '\'':'"',
+                     ',':'<', '.':'>', '-':'_', ';':':', '`':'~',
+                     'a':'A', 'b':'B', 'c':'C', 'd':'D', 'e':'E', 'f':'F', 'g':'G', 'h':'H',
+                     'i':'I', 'j':'J', 'k':'K', 'l':'L', 'm':'M', 'n':'N', 'o':'O', 'p':'P',
+                     'q':'Q', 'r':'R', 's':'S', 't':'T', 'u':'U', 'v':'V', 'w':'W', 'x':'X',
+                     'y':'Y', 'z':'Z' }
+UNSHIFT_MAP = {y: x for x, y in SHIFT_MAP.items()}
+
 # Based on Lukas Peraza's pygame framework
 # https://github.com/LBPeraza/Pygame-Asteroids
-class App(object):
-    shiftMap = { '1':'!', '2':'@', '3':'#', '4':'$', '5':'%', '6':'^', '7':'&', '8':'*',
-                     '9':'(', '0':')', '[':'{', ']':'}', '/':'?', '=':'+', '\\':'|', '\'':'"',
-                     ',':'<', '.':'>', '-':'_', ';':':', '`':'~' }
-    unShiftMap = { '!':'1', '@':'2', '#':'3', '$':'4', '%':'5', '^':'6', '&':'7', '*':'8',
-                    '(':'9', ')':'0', '{':'[', '}':']', '?':'/', '+':'=', '|':'\\', '"':'\'',
-                   '<':',', '>':'.', '_':'-', ':':';', '~':'`' }
-    
+class App(object):    
     def printFullTracebacks(self):
         shape_logic.printFullTracebacks()
 
@@ -484,7 +486,7 @@ class App(object):
         if 33 < keyCode < 127:
             key = chr(keyCode)
             if (modifierMask & pygame.KMOD_SHIFT):
-                key = App.shiftMap.get(key, key).upper()
+                key = SHIFT_MAP.get(key, key)
             return key
         return keyNameMap.get(keyCode, None)
 
@@ -535,12 +537,10 @@ class App(object):
         if key == 'ctrl':
             self.isCtrlKeyDown = False
             return
-        if key.upper() in self._allKeysDown: self._allKeysDown.remove(key.upper())
-        if key.lower() in self._allKeysDown: self._allKeysDown.remove(key.lower())
-        if key in App.shiftMap and App.shiftMap[key] in self._allKeysDown:
-            self._allKeysDown.remove(App.shiftMap[key])
-        if key in App.unShiftMap and App.unShiftMap[key] in self._allKeysDown:
-            self._allKeysDown.remove(App.unShiftMap[key])
+        if key in SHIFT_MAP and SHIFT_MAP[key] in self._allKeysDown:
+            self._allKeysDown.remove(SHIFT_MAP[key])
+        if key in UNSHIFT_MAP and UNSHIFT_MAP[key] in self._allKeysDown:
+            self._allKeysDown.remove(UNSHIFT_MAP[key])
 
         modifiers = self.getModifiers(modifierMask)
         self.callUserFn('onKeyRelease', (key, modifiers))


### PR DESCRIPTION
When holding special characters that require the shift modifier (such as ‘!’ or ‘$’), if shift was released before the key itself, CMU Graphics thought the key was still pressed, and kept calling onKeyHold with it. The same happened if a non-modified key (say, a digit or '/') was held, then a shift is pressed before said key was released. This didn't happen with uppercase and lower case letters, as the App class's handleKeyRelease method already checked for that, but special characters were overlooked.

To fix it, added the shiftMap dictionary (from the getKey method) and unShiftMap (inversion of same dictionary) to App as class variables, then used both in handleKeyRelease to properly release special characters. Also updated getKey so that it doesn't re-define a shiftMap now that it's a class variable.