### PR TITLE
Address deprecation warnings in tests

### DIFF
--- a/tests/test_image_gen.py
+++ b/tests/test_image_gen.py
@@ -5,11 +5,14 @@ import shutil
 import sys
 import time
 
-import imageio
+import imageio.v2 as imageio
 from PIL import Image
 import numpy
 
 import subprocess
+import functools
+
+print = functools.partial(print, flush=True)
 
 SIZE = 400
 


### PR DESCRIPTION
Refer to:
- #81 

Prints became buffered when issue was addressed so the modification to the print function was necessary to retrieve previous unbuffered behaviour.