### PR TITLE
Remove mentions of Coding Rooms in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ project which develops free-to-use middle and high school computer science
 curriculum.
 
 Desktop CMU Graphics works with **Python 3.6-3.11** and is compatible with
-[Replit](https://replit.com/) and [Coding Rooms](https://www.codingrooms.com/)
-(see the "Replit" and "Coding Rooms" sections below). This
-package, including its documentation, is licensed under the
+[Replit](https://replit.com/) (see the "Replit" section below). This package, 
+including its documentation, is licensed under the
 [BSD 3-Clause license](https://github.com/cmu-cs-academy/desktop-cmu-graphics/blob/master/LICENSE).
 
 
@@ -94,14 +93,4 @@ Desktop CMU Graphics is compatible with [Replit](https://replit.com/). To use
 the package on the Replit website:
 
 1. Create a new repl. Choose "Python-CMUGraphics" as the language.
-1. Run your code!
-
-## Coding Rooms
-
-Desktop CMU Graphics is compatible with [Coding Rooms](https://www.codingrooms.com/). To use the package on the
-Coding Rooms website:
-
-1. Visit [this link](https://www.codingrooms.com/compiler/python3) to create a workspace
-1. Click "Start Coding Python for Free Now"
-1. Click the blue "View Desktop" button above the shell
 1. Run your code!


### PR DESCRIPTION
Removes all mentions of the Coding Rooms platforms, as it is being sunset