### PR TITLE
added optional width and height params to run()

### DIFF
--- a/cmu_graphics/cmu_graphics.py
+++ b/cmu_graphics/cmu_graphics.py
@@ -1141,7 +1141,7 @@ class App(object):
             nonlocal lastCall, prevArgs
 
             now = pygame.time.get_ticks()
-            if (now - lastCall >= delay):
+            if now - lastCall >= delay:
                 lastCall = now
                 fn(*args)
                 prevArgs = None
@@ -1160,7 +1160,7 @@ class App(object):
                 fn(*prevArgs)
                 prevArgs = None
                 return True
-            
+
             return False
 
         throttle.flush = flush
@@ -1175,8 +1175,12 @@ class App(object):
         self.updateScreen(True)
 
         lastTick = 0
-        throttledMouseMove = self.throttleEvent(lambda arg: self.callUserFn("onMouseMove", arg), 30)
-        throttledMouseDrag = self.throttleEvent(lambda arg: self.callUserFn("onMouseDrag", arg), 30)
+        throttledMouseMove = self.throttleEvent(
+            lambda arg: self.callUserFn('onMouseMove', arg), 30
+        )
+        throttledMouseDrag = self.throttleEvent(
+            lambda arg: self.callUserFn('onMouseDrag', arg), 30
+        )
         self._running = True
 
         while self._running:
@@ -1202,7 +1206,8 @@ class App(object):
                                     (
                                         *event.pos,
                                         [i for i in range(3) if event.buttons[i] != 0],
-                                    ))
+                                    )
+                                )
                         elif event.type == pygame.KEYDOWN:
                             self.handleKeyPress(event.key, event.mod)
                         elif event.type == pygame.KEYUP:
@@ -1317,6 +1322,7 @@ class AppWrapper(object):
             return self._app.__setattr__(attr, value)
         return super().__setattr__(attr, value)
 
+
 def processRunAppArgs(args, kwargs):
     # Extract width and height (and their translations) from kwargs
     width = 400
@@ -1360,6 +1366,7 @@ def processRunAppArgs(args, kwargs):
 
     return width, height, remaining_kwargs
 
+
 def runApp(*args, **kwargs):
     width, height, remaining_kwargs = processRunAppArgs(args, kwargs)
 
@@ -1394,7 +1401,9 @@ Otherwise, please call cmu_graphics.run() in place of runApp.
 
     # Don't redraw on either of these calls to callUserFn, because we will
     # instead redraw below
-    app._app.callUserFn('onAppStart', (), remaining_kwargs, redraw=False, useActiveScreen=False)            
+    app._app.callUserFn(
+        'onAppStart', (), remaining_kwargs, redraw=False, useActiveScreen=False
+    )
 
     if app._app._initialScreen is not None:
         sortedGlobals = sorted(app._app.userGlobals)
@@ -1420,7 +1429,7 @@ def setActiveScreen(screen, fromRunApp=False):
         )
     if (screen in [None, '']) or (not isinstance(screen, str)):
         raise Exception(f'{repr(screen)} is not a valid screen')
-    
+
     redrawAllFnNames = ['redrawAll']
     redrawAllInCorrectLanguage = 'redrawAll'
     for language, translations in shape_logic.TRANSLATED_USER_FUNCTION_NAMES.items():
@@ -1430,16 +1439,20 @@ def setActiveScreen(screen, fromRunApp=False):
             if redrawAllTranslation not in redrawAllFnNames:
                 redrawAllFnNames.append(redrawAllTranslation)
                 if language == shape_logic.cmuGraphicsLanguage:
-                        redrawAllInCorrectLanguage = redrawAllTranslation
+                    redrawAllInCorrectLanguage = redrawAllTranslation
 
-    if not any(f'{screen}_{fnName}' in app._app.userGlobals for fnName in redrawAllFnNames):
-        raise Exception(t(
-            "Screen '{{screen}}' requires '{{screen}}_{{redrawAllInCorrectLanguage}}()'",
-            {
-                'screen': screen,
-                'redrawAllInCorrectLanguage': redrawAllInCorrectLanguage,
-            }
-        ))
+    if not any(
+        f'{screen}_{fnName}' in app._app.userGlobals for fnName in redrawAllFnNames
+    ):
+        raise Exception(
+            t(
+                "Screen '{{screen}}' requires '{{screen}}_{{redrawAllInCorrectLanguage}}()'",
+                {
+                    'screen': screen,
+                    'redrawAllInCorrectLanguage': redrawAllInCorrectLanguage,
+                },
+            )
+        )
     if fromRunApp:
         app._app.handleSetActiveScreen(screen, redraw=False)
     else:
@@ -1529,7 +1542,27 @@ def loop():
     run()
 
 
-def run():
+def run(*args, **kwargs):
+    width = 400
+    height = 400
+
+    # Handle positional arguments for width and height
+    if len(args) >= 1:
+        width = args[0]
+    if len(args) >= 2:
+        height = args[1]
+    if len(args) > 2:
+        raise TypeError(
+            f'{t("run")}() takes from 0 to 2 positional arguments but {len(args)} were given'
+        )
+
+    # Handle keyword arguments for width and height
+    for param, value in kwargs.items():
+        if toEnglish(param, 'shape-attr') == 'width':
+            width = value
+        elif toEnglish(param, 'shape-attr') == 'height':
+            height = value
+
     if not app._app._isMvc:
         for cs3ModeHandler in ['redrawAll']:
             if cs3ModeHandler in __main__.__dict__:
@@ -1539,6 +1572,9 @@ def run():
 
     global MAINLOOP_RUN
     MAINLOOP_RUN = True
+
+    app.width = width
+    app.height = height
 
     if not os.environ.get('CI', False):
         threading.Thread(target=CSAcademyConsole().interact).start()


### PR DESCRIPTION
Previously, you could not run a window outside of CPCS mode with the dimensions you wanted without having to drag and resize it. Now, you can optionally use:
```python
cmu_graphics.run(width = 500, height = 500)
```
to create a window with a width and height of 500. 
you can choose to put 0-2 of these parameters in, and width and height both default to 400
the window is still resizable when run is called with width and height parameters