### PR TITLE
Use local cmu_graphics_helpers instead of PyPI for tox

### DIFF
--- a/.github/workflows/buildwheels.yml
+++ b/.github/workflows/buildwheels.yml
@@ -1,6 +1,8 @@
 name: Build rust wheels
 
-on: push
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build_wheels:
@@ -71,19 +73,20 @@ jobs:
       with:
         path: cmu_graphics_helpers/target/wheels/*.tar.gz
 
-  # upload_all:
-  #   name: Upload to PyPi
-  #   needs: [build_wheels, make_sdist]
-  #   environment: pypi
-  #   permissions:
-  #     id-token: write
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/download-artifact@v5
-  #     with:
-  #       path: dist
-  #       merge-multiple: true
+  upload_all:
+    name: Upload to PyPi
+    needs: [build_wheels, make_sdist]
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    environment: pypi
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v5
+      with:
+        path: dist
+        merge-multiple: true
 
-  #   - uses: pypa/gh-action-pypi-publish@release/v1
-  #     with:
-  #       repository-url: https://upload.pypi.org/legacy/
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://upload.pypi.org/legacy/

--- a/.github/workflows/buildwheels.yml
+++ b/.github/workflows/buildwheels.yml
@@ -1,7 +1,6 @@
-name: Build rust wheels
+name: Build cmu_graphics_helpers (+ deploy to PyPI if on main)
 
 on:
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,7 +76,7 @@ for:
       - export PATH=/usr/local/bin:$PATH
       # Rust + cargo, needed to build cmu_graphics_helpers. Upgrade the
       # toolchain already present on the build worker image.
-      - "$HOME/.cargo/bin/rustup" update stable
+      - $HOME/.cargo/bin/rustup update stable
       - export PATH="$HOME/.cargo/bin:$PATH"
 
     before_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 
   matrix:
     - job_name: Windows Tests
-      appveyor_build_worker_image: Visual Studio 2019
+      appveyor_build_worker_image: Visual Studio 2022
 
     - job_name: macOS Tests
       appveyor_build_worker_image: macos-sonoma

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,12 +26,23 @@ for:
         - job_name: Windows Tests
 
     install:
-      - C:\Python311-x64\python.exe -m pip install tox twine build
+      - C:\Python311-x64\python.exe -m pip install tox twine build maturin
+      # Rust + cargo, needed to build cmu_graphics_helpers (skipped if the
+      # build worker image already has them).
+      - ps: if (-not (Get-Command rustc -ErrorAction SilentlyContinue)) { Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe; .\rustup-init.exe -y --default-toolchain stable-x86_64-pc-windows-msvc --profile minimal }
+      # LLVM/libclang, needed by bindgen (a build dependency of skia-bindings).
+      - choco install llvm -y --no-progress
+      - set PATH=%USERPROFILE%\.cargo\bin;C:\Program Files\LLVM\bin;%PATH%
+      - set LIBCLANG_PATH=C:\Program Files\LLVM\bin
 
     before_test:
+      - set PATH=%USERPROFILE%\.cargo\bin;C:\Program Files\LLVM\bin;%PATH%
+      - set LIBCLANG_PATH=C:\Program Files\LLVM\bin
       - C:\Python311-x64\python.exe build/build.py
 
     test_script:
+      - set PATH=%USERPROFILE%\.cargo\bin;C:\Program Files\LLVM\bin;%PATH%
+      - set LIBCLANG_PATH=C:\Program Files\LLVM\bin
       - C:\Python311-x64\python.exe -m tox --parallel 2
 
     # See more info on RDP here:
@@ -55,19 +66,24 @@ for:
       - brew install cairo pkg-config python@3.13 python@3.14
       - export PYBIN=~/venv3.11/bin/python
       - $PYBIN -m pip install -U pip
-      - $PYBIN -m pip install tox twine build
+      - $PYBIN -m pip install tox twine build maturin
       # Put /usr/local/bin at the front of PATH so that homebrew's pkg-config will
       # be run by pip. On 27 Aug 2021, with
       # the default PATH value, `which pkg-config` returned
       # /Library/Frameworks/Mono.framework/Home/bin/pkg-config
       - export PATH=/usr/local/bin:$PATH
+      # Rust + cargo, needed to build cmu_graphics_helpers (skipped if the
+      # build worker image already has them).
+      - command -v cargo >/dev/null 2>&1 || curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
+      - export PATH="$HOME/.cargo/bin:$PATH"
 
     before_test:
-      - export PATH=$PATH:~/venv3.11/bin/
+      - export PATH=$PATH:~/venv3.11/bin/:$HOME/.cargo/bin
       - export ARCHFLAGS="-arch x86_64"
       - $PYBIN build/build.py
 
     test_script:
+      - export PATH=$PATH:~/venv3.11/bin/:$HOME/.cargo/bin
       - $PYBIN -m tox --parallel 2
 
     # on_finish:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,10 +30,8 @@ for:
       # Rust + cargo, needed to build cmu_graphics_helpers. Not preinstalled
       # on this image (unlike the macOS image), so install it from scratch.
       - ps: |
-          $ErrorActionPreference = 'Continue'
-          $PSNativeCommandUseErrorActionPreference = $false
           Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
-          .\rustup-init.exe -y --default-toolchain stable-x86_64-pc-windows-msvc --profile minimal
+          .\rustup-init.exe -y --default-toolchain stable-x86_64-pc-windows-msvc --profile minimal 2>$null
       # LLVM/libclang, needed by bindgen (a build dependency of skia-bindings).
       - choco install llvm -y --no-progress
       - set PATH=%USERPROFILE%\.cargo\bin;C:\Program Files\LLVM\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,9 +27,11 @@ for:
 
     install:
       - C:\Python311-x64\python.exe -m pip install tox twine build maturin
-      # Rust + cargo, needed to build cmu_graphics_helpers (skipped if the
-      # build worker image already has them).
-      - ps: if (-not (Get-Command rustc -ErrorAction SilentlyContinue)) { Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe; .\rustup-init.exe -y --default-toolchain stable-x86_64-pc-windows-msvc --profile minimal }
+      # Rust + cargo, needed to build cmu_graphics_helpers. Upgrade the
+      # toolchain already present on the build worker image.
+      - ps: |
+          $ErrorActionPreference = 'Continue'
+          & "$env:USERPROFILE\.cargo\bin\rustup.exe" update stable
       # LLVM/libclang, needed by bindgen (a build dependency of skia-bindings).
       - choco install llvm -y --no-progress
       - set PATH=%USERPROFILE%\.cargo\bin;C:\Program Files\LLVM\bin;%PATH%
@@ -72,9 +74,9 @@ for:
       # the default PATH value, `which pkg-config` returned
       # /Library/Frameworks/Mono.framework/Home/bin/pkg-config
       - export PATH=/usr/local/bin:$PATH
-      # Rust + cargo, needed to build cmu_graphics_helpers (skipped if the
-      # build worker image already has them).
-      - command -v cargo >/dev/null 2>&1 || curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
+      # Rust + cargo, needed to build cmu_graphics_helpers. Upgrade the
+      # toolchain already present on the build worker image.
+      - "$HOME/.cargo/bin/rustup" update stable
       - export PATH="$HOME/.cargo/bin:$PATH"
 
     before_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,11 +27,12 @@ for:
 
     install:
       - C:\Python311-x64\python.exe -m pip install tox twine build maturin
-      # Rust + cargo, needed to build cmu_graphics_helpers. Upgrade the
-      # toolchain already present on the build worker image.
+      # Rust + cargo, needed to build cmu_graphics_helpers. Not preinstalled
+      # on this image (unlike the macOS image), so install it from scratch.
       - ps: |
           $ErrorActionPreference = 'Continue'
-          rustup update stable
+          Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
+          .\rustup-init.exe -y --default-toolchain stable-x86_64-pc-windows-msvc --profile minimal
       # LLVM/libclang, needed by bindgen (a build dependency of skia-bindings).
       - choco install llvm -y --no-progress
       - set PATH=%USERPROFILE%\.cargo\bin;C:\Program Files\LLVM\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ for:
       # toolchain already present on the build worker image.
       - ps: |
           $ErrorActionPreference = 'Continue'
-          & "$env:USERPROFILE\.cargo\bin\rustup.exe" update stable
+          rustup update stable
       # LLVM/libclang, needed by bindgen (a build dependency of skia-bindings).
       - choco install llvm -y --no-progress
       - set PATH=%USERPROFILE%\.cargo\bin;C:\Program Files\LLVM\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ for:
       - C:\Python311-x64\python.exe -m pip install tox twine build maturin
       # Rust + cargo, needed to build cmu_graphics_helpers. Not preinstalled
       # on this image (unlike the macOS image), so install it from scratch.
+      - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
       - ps: |
           Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
           .\rustup-init.exe -y --default-toolchain stable-x86_64-pc-windows-msvc --profile minimal 2>$null
@@ -51,8 +52,8 @@ for:
     #   https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
     # The password for the RDP user is listed here:
     #   https://ci.appveyor.com/project/austin-schick/cpython-cmu-graphics-0l7rb/settings/environment
-    # on_finish:
-    #   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+    on_finish:
+      - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
   -
     matrix:
@@ -88,6 +89,6 @@ for:
       - export PATH=$PATH:~/venv3.11/bin/:$HOME/.cargo/bin
       - $PYBIN -m tox --parallel 2
 
-    on_finish:
-      - export APPVEYOR_SSH_BLOCK=true
-      - curl -sflL 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-ssh.sh' | bash -e -
+    # on_finish:
+    #   - export APPVEYOR_SSH_BLOCK=true
+    #   - curl -sflL 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-ssh.sh' | bash -e -

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ for:
       # on this image (unlike the macOS image), so install it from scratch.
       - ps: |
           $ErrorActionPreference = 'Continue'
+          $PSNativeCommandUseErrorActionPreference = $false
           Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
           .\rustup-init.exe -y --default-toolchain stable-x86_64-pc-windows-msvc --profile minimal
       # LLVM/libclang, needed by bindgen (a build dependency of skia-bindings).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,9 +75,9 @@ for:
       # the default PATH value, `which pkg-config` returned
       # /Library/Frameworks/Mono.framework/Home/bin/pkg-config
       - export PATH=/usr/local/bin:$PATH
-      # Rust + cargo, needed to build cmu_graphics_helpers. Upgrade the
-      # toolchain already present on the build worker image.
-      - $HOME/.cargo/bin/rustup update stable
+      # Rust + cargo, needed to build cmu_graphics_helpers. Not preinstalled
+      # on this image, so install it from scratch.
+      - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
       - export PATH="$HOME/.cargo/bin:$PATH"
 
     before_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,8 +52,8 @@ for:
     #   https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
     # The password for the RDP user is listed here:
     #   https://ci.appveyor.com/project/austin-schick/cpython-cmu-graphics-0l7rb/settings/environment
-    # on_finish:
-    #   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+    on_finish:
+      - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
   -
     matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,20 +27,13 @@ for:
 
     install:
       - C:\Python311-x64\python.exe -m pip install tox twine build maturin
-      # Rust + cargo, needed to build cmu_graphics_helpers. Not preinstalled
-      # on this image (unlike the macOS image), so install it from scratch.
-      # Plain cmd.exe (not PowerShell) so a stderr line from rustup-init.exe
-      # can't get turned into a build-failing PowerShell error record.
+      # Rust + cargo, needed to build cmu_graphics_helpers.
       - curl -sSf -o rustup-init.exe https://win.rustup.rs/x86_64
       - rustup-init.exe -y --default-toolchain stable-x86_64-pc-windows-msvc --profile minimal
       # LLVM/libclang, needed by bindgen (a build dependency of skia-bindings).
       - choco install llvm -y --no-progress
-      - set PATH=%USERPROFILE%\.cargo\bin;C:\Program Files\LLVM\bin;%PATH%
-      - set LIBCLANG_PATH=C:\Program Files\LLVM\bin
 
     before_test:
-      - set PATH=%USERPROFILE%\.cargo\bin;C:\Program Files\LLVM\bin;%PATH%
-      - set LIBCLANG_PATH=C:\Program Files\LLVM\bin
       - C:\Python311-x64\python.exe build/build.py
 
     test_script:
@@ -52,8 +45,8 @@ for:
     #   https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
     # The password for the RDP user is listed here:
     #   https://ci.appveyor.com/project/austin-schick/cpython-cmu-graphics-0l7rb/settings/environment
-    on_finish:
-      - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+    # on_finish:
+    #   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
   -
     matrix:
@@ -75,8 +68,7 @@ for:
       # the default PATH value, `which pkg-config` returned
       # /Library/Frameworks/Mono.framework/Home/bin/pkg-config
       - export PATH=/usr/local/bin:$PATH
-      # Rust + cargo, needed to build cmu_graphics_helpers. Not preinstalled
-      # on this image, so install it from scratch.
+      # Rust + cargo, needed to build cmu_graphics_helpers.
       - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable --profile minimal
       - export PATH="$HOME/.cargo/bin:$PATH"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,6 +88,6 @@ for:
       - export PATH=$PATH:~/venv3.11/bin/:$HOME/.cargo/bin
       - $PYBIN -m tox --parallel 2
 
-    # on_finish:
-    #   - export APPVEYOR_SSH_BLOCK=true
-    #   - curl -sflL 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-ssh.sh' | bash -e -
+    on_finish:
+      - export APPVEYOR_SSH_BLOCK=true
+      - curl -sflL 'https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-ssh.sh' | bash -e -

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,10 +29,10 @@ for:
       - C:\Python311-x64\python.exe -m pip install tox twine build maturin
       # Rust + cargo, needed to build cmu_graphics_helpers. Not preinstalled
       # on this image (unlike the macOS image), so install it from scratch.
-      - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-      - ps: |
-          Invoke-WebRequest -Uri https://win.rustup.rs/x86_64 -OutFile rustup-init.exe
-          .\rustup-init.exe -y --default-toolchain stable-x86_64-pc-windows-msvc --profile minimal 2>$null
+      # Plain cmd.exe (not PowerShell) so a stderr line from rustup-init.exe
+      # can't get turned into a build-failing PowerShell error record.
+      - curl -sSf -o rustup-init.exe https://win.rustup.rs/x86_64
+      - rustup-init.exe -y --default-toolchain stable-x86_64-pc-windows-msvc --profile minimal
       # LLVM/libclang, needed by bindgen (a build dependency of skia-bindings).
       - choco install llvm -y --no-progress
       - set PATH=%USERPROFILE%\.cargo\bin;C:\Program Files\LLVM\bin;%PATH%
@@ -52,8 +52,8 @@ for:
     #   https://www.appveyor.com/docs/how-to/rdp-to-build-worker/
     # The password for the RDP user is listed here:
     #   https://ci.appveyor.com/project/austin-schick/cpython-cmu-graphics-0l7rb/settings/environment
-    on_finish:
-      - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+    # on_finish:
+    #   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
   -
     matrix:

--- a/build/check_helpers_version.py
+++ b/build/check_helpers_version.py
@@ -1,0 +1,51 @@
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def cargo_version():
+    with open(ROOT / 'cmu_graphics_helpers' / 'Cargo.toml', 'rb') as f:
+        return tomllib.load(f)['package']['version']
+
+
+def pyproject_pin():
+    with open(ROOT / 'pyproject.toml', 'rb') as f:
+        data = tomllib.load(f)
+
+    for dep in data['project']['dependencies']:
+        match = re.fullmatch(r'cmu-graphics-helpers==(.+)', dep)
+        if match:
+            return match.group(1)
+
+    raise SystemExit('cmu-graphics-helpers dependency not found in pyproject.toml')
+
+
+def tox_ini_pin():
+    text = (ROOT / 'tox.ini').read_text()
+    match = re.search(r'cmu-graphics-helpers==(\S+)', text)
+    if not match:
+        raise SystemExit('cmu-graphics-helpers dependency not found in tox.ini')
+    return match.group(1)
+
+
+def main():
+    versions = {
+        'cmu_graphics_helpers/Cargo.toml': cargo_version(),
+        'pyproject.toml': pyproject_pin(),
+        'tox.ini': tox_ini_pin(),
+    }
+
+    if len(set(versions.values())) > 1:
+        details = ', '.join(f'{path}={v}' for path, v in versions.items())
+        print(
+            f'cmu-graphics-helpers version mismatch: {details}. Keep these in sync.',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/cmu_graphics_helpers/Cargo.lock
+++ b/cmu_graphics_helpers/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "cmu-graphics-helpers"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "geo",
  "geo-booleanop",

--- a/cmu_graphics_helpers/Cargo.toml
+++ b/cmu_graphics_helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmu-graphics-helpers"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 dependencies = [
     "pygame-ce>=2",
     "pycairo>=1.20",
-    "cmu-graphics-helpers==0.1.3"
+    "cmu-graphics-helpers==0.1.4"
 ]
 
 [project.urls]

--- a/tox.ini
+++ b/tox.ini
@@ -7,17 +7,21 @@ changedir = {envtmpdir}
 passenv = CI
 setenv   =
     PYTHONPATH = {envtmpdir}
+# Make sure the helpers wheel is built (just once) before any test env tries
+# to install it, since building it once per parallel env races on the shared
+# cmu_graphics_helpers/target/ output.
+depends = build-helpers
 deps =
-  # Build cmu_graphics_helpers from this repo instead of tox
-  # fetching the pinned release from PyPI.
-  {toxinidir}{/}cmu_graphics_helpers
+  # Installed from the wheel built by the build-helpers env below, instead
+  # of tox fetching the pinned release from PyPI.
+  cmu-graphics-helpers==0.1.4
   # These dependencies are need to run test_image_gen.py. No additional
   # dependencies of cmu_graphics need to be listed here.
   psutil
   pillow
   imageio
   numpy
-install_command = python -m pip install --no-cache-dir {opts} {packages}
+install_command = python -m pip install --no-cache-dir --find-links {toxinidir}{/}cmu_graphics_helpers{/}target{/}wheels {opts} {packages}
 commands =
   pip: python {toxinidir}{/}tests{/}install.py pip {toxinidir}
   zip: python {toxinidir}{/}tests{/}install.py zip {toxinidir}
@@ -26,3 +30,11 @@ commands =
   python {toxinidir}{/}tests{/}test_sound.py
   python {toxinidir}{/}tests{/}test_image_gen.py
   python {toxinidir}{/}tests{/}check_binaries.py
+
+[testenv:build-helpers]
+description = Build the cmu_graphics_helpers wheel once, so parallel test envs don't race building it themselves
+changedir = {toxinidir}
+depends =
+skip_install = true
+deps = maturin
+commands = maturin build --release -m {toxinidir}{/}cmu_graphics_helpers{/}Cargo.toml

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{311,312,313,314}-{pip,zip}
+envlist=build-helpers,py{311,312,313,314}-{pip,zip}
 skipsdist=True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,8 @@ setenv   =
 depends = build-helpers
 deps =
   # Installed from the wheel built by the build-helpers env below, instead
-  # of tox fetching the pinned release from PyPI.
+  # of tox fetching the pinned release from PyPI. build/check_helpers_version.py
+  # (run by build-helpers) verifies this stays in sync with Cargo.toml/pyproject.toml.
   cmu-graphics-helpers==0.1.4
   # These dependencies are need to run test_image_gen.py. No additional
   # dependencies of cmu_graphics need to be listed here.
@@ -37,4 +38,6 @@ changedir = {toxinidir}
 depends =
 skip_install = true
 deps = maturin
-commands = maturin build --release -m {toxinidir}{/}cmu_graphics_helpers{/}Cargo.toml
+commands =
+  python {toxinidir}{/}build{/}check_helpers_version.py
+  maturin build --release -m {toxinidir}{/}cmu_graphics_helpers{/}Cargo.toml

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,11 @@ passenv = CI
 setenv   =
     PYTHONPATH = {envtmpdir}
 deps =
-  # These dependencies are need to run test_image_gen.py. No dependencies
-  # of cmu_graphics need to be listed here.
+  # Build cmu_graphics_helpers from this repo instead of tox
+  # fetching the pinned release from PyPI.
+  {toxinidir}{/}cmu_graphics_helpers
+  # These dependencies are need to run test_image_gen.py. No additional
+  # dependencies of cmu_graphics need to be listed here.
   psutil
   pillow
   imageio


### PR DESCRIPTION
* Renamed the Github "build rust wheels" action. Only deploy the files to PyPI when you trigger the action on the `main` branch.
* Build the cmu-graphics-helpers wheel on Appveyor before running tests so that the *-pip environments can succeed when cmu-graphics-helpers has changed. 